### PR TITLE
Chain Sync Improvements: Phase 1

### DIFF
--- a/examples/src/main/kotlin/org/dashevo/examples/CreateIdentity.kt
+++ b/examples/src/main/kotlin/org/dashevo/examples/CreateIdentity.kt
@@ -8,6 +8,7 @@ package org.dashevo.examples
 
 import org.bitcoinj.evolution.CreditFundingTransaction
 import org.dashevo.Client
+import org.dashevo.dpp.identity.IdentityPublicKey
 import org.dashevo.dpp.toBase64
 import org.json.JSONObject
 import java.lang.Thread.sleep
@@ -33,7 +34,7 @@ class CreateIdentity {
 
                 if (identity == null) {
                     // only create the identity if it does not exist
-                    platform.identities.register(cftx)
+                    platform.identities.register(cftx, listOf(IdentityPublicKey(0, IdentityPublicKey.TYPES.ECDSA_SECP256K1, DefaultIdentity.publicKey.toBase64(), true)))
                     sleep(10000)
                     identity = platform.identities.get(cftx.creditBurnIdentityIdentifier.toString())
                 }

--- a/platform-core/src/main/kotlin/org/dashevo/platform/Identities.kt
+++ b/platform-core/src/main/kotlin/org/dashevo/platform/Identities.kt
@@ -20,6 +20,7 @@ class Identities(val platform: Platform) {
 
     fun register(
         signedLockTransaction: CreditFundingTransaction,
+        identityPublicKeys: List<IdentityPublicKey>,
         keyCrypter: KeyCrypter?,
         keyParameter: KeyParameter?
     ): String {
@@ -27,41 +28,31 @@ class Identities(val platform: Platform) {
         return register(
             signedLockTransaction.lockedOutpoint,
             identityPrivateKey,
-            signedLockTransaction.usedDerivationPathIndex
+            identityPublicKeys
         )
     }
 
     fun register(
-        signedLockTransaction: CreditFundingTransaction
+        signedLockTransaction: CreditFundingTransaction,
+        identityPublicKeys: List<IdentityPublicKey>
     ): String {
         return register(
             signedLockTransaction.lockedOutpoint,
             signedLockTransaction.creditBurnPublicKey,
-            signedLockTransaction.usedDerivationPathIndex
+            identityPublicKeys
         )
     }
 
     fun register(
         lockedOutpoint: TransactionOutPoint,
         creditBurnKey: ECKey,
-        usedDerivationPathIndex: Int
+        identityPublicKeys: List<IdentityPublicKey>
     ): String {
 
         try {
             val outPoint = lockedOutpoint.toStringBase64()
-            // FIXME (this will be fixed later, for now add one to the actual index)
-            // This will be fixed in DPP 0.12
-            val publicKeyId = usedDerivationPathIndex
 
-            val identityPublicKeyModel = IdentityPublicKey(
-                publicKeyId,
-                IdentityPublicKey.TYPES.ECDSA_SECP256K1,
-                creditBurnKey.pubKey.toBase64(),
-                true
-            )
-
-            val identityCreateTransition = platform.dpp.identity.createIdentityCreateTransition(outPoint, listOf(identityPublicKeyModel))
-                //IdentityCreateTransition(outPoint, listOf(identityPublicKeyModel))
+            val identityCreateTransition = platform.dpp.identity.createIdentityCreateTransition(outPoint, identityPublicKeys)
 
             identityCreateTransition.signByPrivateKey(creditBurnKey)
 


### PR DESCRIPTION
Goals:

- Align derivation paths with iOS (this is in a dashj PR)
- Align keys uses in Identities with iOS

Key alignment with iOS

- Identity registration transitions are still signed by the key that has its P2PKH in the credit burn output

- Identity public keys are now taken from the blockchain identity derivation path, from wallet.blockchainIdentityKeyChain, currently only index 0.

This PR depends on #14 