### PR TITLE
BlockchainIdentity: Modify Constructor

### DIFF
--- a/dashpay/src/main/kotlin/org/dashevo/dashpay/BlockchainIdentity.kt
+++ b/dashpay/src/main/kotlin/org/dashevo/dashpay/BlockchainIdentity.kt
@@ -195,7 +195,8 @@ class BlockchainIdentity {
     constructor(
         platform: Platform,
         transaction: CreditFundingTransaction,
-        wallet: Wallet
+        wallet: Wallet,
+        registeredIdentity: Identity? = null
     ) :
             this(platform, transaction.usedDerivationPathIndex, transaction.lockedOutpoint, wallet) {
         Preconditions.checkArgument(!transaction.creditBurnPublicKey.isPubKeyOnly || transaction.creditBurnPublicKey.isEncrypted)
@@ -204,11 +205,17 @@ class BlockchainIdentity {
 
         //see if the identity is registered.
         try {
-            if (platform.identities.get(uniqueIdString) != null)
-                registrationStatus = RegistrationStatus.REGISTERED
-            else registrationStatus = RegistrationStatus.UNKNOWN
+            identity = if (registeredIdentity != null) {
+                registeredIdentity
+            } else {
+                platform.identities.get(uniqueIdString)
+            }
+            registrationStatus = if (identity != null)
+                RegistrationStatus.REGISTERED
+            else RegistrationStatus.UNKNOWN
         } catch (x: Exception) {
-            //swallow and leave the status as unknown
+            // swallow and leave the status as unknown
+            registrationStatus = RegistrationStatus.UNKNOWN
         }
     }
 

--- a/examples/src/main/java/org/dashevo/examples/ForwardingServiceEvo.java
+++ b/examples/src/main/java/org/dashevo/examples/ForwardingServiceEvo.java
@@ -235,7 +235,7 @@ public class ForwardingServiceEvo {
                     System.out.println("  no names found");
                 }
             }
-            BlockchainIdentity blockchainIdentity = new BlockchainIdentity(platform, tx, kit.wallet());
+            BlockchainIdentity blockchainIdentity = new BlockchainIdentity(platform, tx, kit.wallet(), null);
 
             List<String> names = ImmutableList.of("test1", "test2");
 
@@ -379,12 +379,12 @@ public class ForwardingServiceEvo {
                     System.out.println("Blockchain Identity Funding Transaction hash is " + sendResult.tx.getTxId());
                     System.out.println(sendResult.tx.toString());
                     System.out.println("Blockchain Identity object Initialization" + sendResult.tx.getTxId());
-                    blockchainIdentity = new BlockchainIdentity(platform, (CreditFundingTransaction)sendRequest.tx, kit.wallet());
+                    blockchainIdentity = new BlockchainIdentity(platform, (CreditFundingTransaction)sendRequest.tx, kit.wallet(), null);
                 }
             }, MoreExecutors.directExecutor());
 
             lastTx = (CreditFundingTransaction)sendResult.tx;
-            lastBlockchainIdentity = new BlockchainIdentity(platform, lastTx, kit.wallet());
+            lastBlockchainIdentity = new BlockchainIdentity(platform, lastTx, kit.wallet(), null);
 
             System.out.println("Creating identity");
             registerIdentity();


### PR DESCRIPTION
This PR allows a call to a BlockchainIdentity constructor and specify the related identity.  If specified, then this constructor will not call getIdentity().

This will speed up the execution of the constructor.