### PR TITLE
changed  https://github.com/github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ This library consists of two components
 # Building
 This depends on the `android-dpp` and `dapi-client-android` libraries:
 ```
-git clone https://github.com/github/dashevo/android-dpp.git
+git clone https://github.com/dashevo/android-dpp.git
 cd android-dpp
 ./gradlew assemble
 cd ..
-git clone https://github.com/github/dashevo/dapi-client-android.git
+git clone https://github.com/dashevo/dapi-client-android.git
 cd dapi-client-android
 ./gradlew assemble
 cd ..
 ```
 Finally, build the library:
 ```
-git clone https://github.com/github/dashevo/android-dashpay.git`
+git clone https://github.com/dashevo/android-dashpay.git`
 cd android-dashpay`
 ./gradlew assemble`
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

 The github links in the Readme containing the various repository is misleading. If you do not look at it you will think the links are all private or does not exist. One can simply pass it or think its private source.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
The link was changed from https://github.com/github/dashevo/android-dpp.git to https://github.com/dashevo/android-dpp.git
<!--- Describe your changes in detail -->


